### PR TITLE
Add Promise.lift.

### DIFF
--- a/PinkyPromise.playground/Pages/Promise.xcplaygroundpage/Contents.swift
+++ b/PinkyPromise.playground/Pages/Promise.xcplaygroundpage/Contents.swift
@@ -30,6 +30,21 @@ trivialSuccess.call { result in
 }
 
 /*:
+ If you have a returning-or-throwing function, you can wrap it in a Promise.
+ The promise will run the function and return its success or failure value.
+ */
+
+func dashedLine() throws -> String {
+    let width = Int(arc4random_uniform(20)) - 10
+    guard 0 <= width else {
+        throw someError
+    }
+    return Array(count: width, repeatedValue: "-").joinWithSeparator("")
+}
+
+let dashedLinePromise = Promise.lift(dashedLine)
+
+/*:
  ## Asynchronous operations
 
  Most of the time you want a Promise to run an asynchronous operation that can succeed or fail.

--- a/PinkyPromiseTests/PromiseTest.swift
+++ b/PinkyPromiseTests/PromiseTest.swift
@@ -133,6 +133,37 @@ class PromiseTest: XCTestCase {
         waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
+    func testLift() {
+        do {
+            let expectedValue = "someValue"
+            let promise = Promise.lift {
+                expectedValue
+            }
+
+            let completionCalled = expectationWithDescription("Completion was called")
+            promise.call { result in
+                completionCalled.fulfill()
+                TestHelpers.expectSuccess(expectedValue, result: result, message: "Expected the given value.")
+            }
+        }
+
+        do {
+            let expectedError = TestHelpers.uniqueError()
+            let promise = Promise.lift {
+                throw expectedError
+            }
+
+            let completionCalled = expectationWithDescription("Completion was called")
+            promise.call { result in
+                completionCalled.fulfill()
+                TestHelpers.expectFailure(expectedError, result: result)
+            }
+
+        }
+
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+
     func testMap() {
         // Map success to success
         do {

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -66,6 +66,15 @@ public struct Promise<T> {
         self.init(result: .Failure(error))
     }
 
+    // A promise that creates its value or error when called.
+    // Lifts the notion of producing a Result into Promise context.
+    // Or, lifts a synchonous function into asynchronous context.
+    public static func lift(produce: () throws -> Value) -> Promise<Value> {
+        return Promise { fulfill in
+            fulfill(Result(create: produce))
+        }
+    }
+
     // MARK: Promise transformations
 
     // Produces a composite promise that resolves by calling this promise, then transforming its success value.


### PR DESCRIPTION
For example, my current app's API query objects are stateful, but I want to make my endpoint promises callable more than once. So:

```
Promise.lift(createQuery)
    .flatMap(executeQuery)
    .tryMap(jsonToNativeValue)
    .call { … }
```

is simpler than:

```
Promise { fulfill in
    fulfill(Result { createQuery() })
}
.flatMap(executeQuery)
.tryMap(jsonToNativeValue)
.call { … }
```