### PR TITLE
Add Promise.result.

### DIFF
--- a/PinkyPromise.playground/Pages/Promise.xcplaygroundpage/Contents.swift
+++ b/PinkyPromise.playground/Pages/Promise.xcplaygroundpage/Contents.swift
@@ -112,9 +112,10 @@ stringPromise.call { result in
  - `retry` to repeat the Promise until it's successful, or until a failure count is reached.
  - `inBackground` to run a Promise in the background, then complete on the main queue.
  - `inDispatchGroup` to run a Promise as a task in a GCD dispatch group.
+ - `result` to add a step to perform without modifying the result.
  - `success` to add a step to perform only when successful.
  - `failure` to add a step to perform only when failing.
- 
+
  > Remember that a `Promise` value is an operation that hasn't been started yet and that can produce a value or error. We are transforming operations that haven't been started into other operations that we can start instead.
  */
 
@@ -147,6 +148,9 @@ let complexPromise =
             .map { "\($0) then extended on the main queue" }
     )
     .retry(3)
+    .result { result in
+        print("Complex promise produced success or failure: \(result)")
+    }
     .success { int, string in
         print("Complex promise succeeded. Multiple of two: \(int), string: \(string)")
     }

--- a/PinkyPromiseTests/PromiseTest.swift
+++ b/PinkyPromiseTests/PromiseTest.swift
@@ -515,6 +515,48 @@ class PromiseTest: XCTestCase {
         waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
+    func testResult() {
+        // With success
+        do {
+            let expectedValue = 3
+            let initialPromise = Promise(value: expectedValue)
+            
+            let resultCalled = expectationWithDescription("Result block was called")
+            let promise = initialPromise.result { result in
+                resultCalled.fulfill()
+                TestHelpers.expectSuccess(3, result: result, message: "Expected the given success value.")
+            }
+            
+            let completionCalled = expectationWithDescription("Completion was called")
+            promise.call { result in
+                completionCalled.fulfill()
+                TestHelpers.expectSuccess(expectedValue, result: result, message: "Expected the given success value.")
+            }
+            
+            waitForExpectationsWithTimeout(1.0, handler: nil)
+        }
+
+        // With failure
+        do {
+            let expectedError = TestHelpers.uniqueError()
+            let initialPromise = Promise<Int>(error: expectedError)
+
+            let resultCalled = expectationWithDescription("Failure block was called")
+            let promise = initialPromise.result { result in
+                resultCalled.fulfill()
+                TestHelpers.expectFailure(expectedError, result: result)
+            }
+
+            let completionCalled = expectationWithDescription("Completion was called")
+            promise.call { result in
+                completionCalled.fulfill()
+                TestHelpers.expectFailure(expectedError, result: result)
+            }
+
+            waitForExpectationsWithTimeout(1.0, handler: nil)
+        }
+    }
+
     func testSuccess() {
         // Succeed
         do {

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -174,26 +174,30 @@ public struct Promise<T> {
 
     // MARK: Result delivery
 
-    // Produces a composite promise that resolves by calling this promise, but also performs another task if successful.
-    public func success(successTask: (Value) -> Void) -> Promise<Value> {
+    // Produces a composite promise that resolves by calling this promise, but also performs another task.
+    public func result(resultTask: (Result<Value>) -> Void) -> Promise<Value> {
         return Promise { fulfill in
             self.call { result in
-                if case .Success(let value) = result {
-                    successTask(value)
-                }
+                resultTask(result)
                 fulfill(result)
+            }
+        }
+    }
+
+    // Produces a composite promise that resolves by calling this promise, but also performs another task if successful.
+    public func success(successTask: (Value) -> Void) -> Promise<Value> {
+        return result { result in
+            if case .Success(let value) = result {
+                successTask(value)
             }
         }
     }
 
     // Produces a composite promise that resolves by calling this promise, but also performs another task if failed.
     public func failure(failureTask: (ErrorType) -> Void) -> Promise<Value> {
-        return Promise { fulfill in
-            self.call { result in
-                if case .Failure(let error) = result {
-                    failureTask(error)
-                }
-                fulfill(result)
+        return result { result in
+            if case .Failure(let error) = result {
+                failureTask(error)
             }
         }
     }


### PR DESCRIPTION
This Promise transformation works like `.success` or `.failure`, but always runs its task regardless of success or failure.

`.success` and `.failure` were really named after the conditions under which they happen, not the value or error they contain, so I think `.result` is not that good of a name. What should I call it?