### PR TITLE
Add new always() function

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -294,6 +294,20 @@ public struct Promise<Value> {
             }
         }
     }
+    
+    /**
+     Creates a promise that wraps this promise and performs a secondary task regardless of success or failure.
+     
+     - parameter resultTask: A function to be called that returns a promise.
+     - returns: A promise whose task runs this promise, and then calls the result task after it succeeds or fails.
+     */
+    public func always<U>(_ resultTask: @escaping () -> Promise<U>) -> Promise<U> {
+        return map { _ in () }.recover { _ in
+            Promise<()>(value: ())
+        }.flatMap { _ in
+            return resultTask()
+        }
+    }
 
     // MARK: Invoking the Promise
 

--- a/Tests/PinkyPromiseTests/PromiseTest.swift
+++ b/Tests/PinkyPromiseTests/PromiseTest.swift
@@ -558,6 +558,50 @@ class PromiseTest: XCTestCase {
             waitForExpectations(timeout: 1.0, handler: nil)
         }
     }
+    
+    func testAlways() {
+        // Success to success
+        do {
+            let expectedValue = 3
+            let unusedValue = "dummy"
+            let initialPromise = Promise(value: unusedValue)
+            
+            let resultCalled = expectation(description: "Result block was called")
+            let promise = initialPromise.always { () -> Promise<Int> in
+                resultCalled.fulfill()
+                return Promise(value: expectedValue)
+            }
+            
+            let completionCalled = expectation(description: "Completion was called")
+            promise.call { result in
+                TestHelpers.expectSuccess(expectedValue, result: result, message: "Expected the given success value.")
+                completionCalled.fulfill()
+            }
+            
+            waitForExpectations(timeout: 1.0, handler: nil)
+        }
+        
+        // Failure to success
+        do {
+            let expectedValue = 3
+            let expectedError = TestHelpers.uniqueError()
+            let initialPromise = Promise<Any>(error: expectedError)
+            
+            let resultCalled = expectation(description: "Result block was called")
+            let promise = initialPromise.always { () -> Promise<Int> in
+                resultCalled.fulfill()
+                return Promise(value: expectedValue)
+            }
+            
+            let completionCalled = expectation(description: "Completion was called")
+            promise.call { result in
+                TestHelpers.expectSuccess(expectedValue, result: result, message: "Expected the given success value.")
+                completionCalled.fulfill()
+            }
+            
+            waitForExpectations(timeout: 1.0, handler: nil)
+        }
+    }
 
     func testSuccess() {
         // Succeed


### PR DESCRIPTION
Add a function that allows a promise to be run after the completion of an initial promise regardless of success or failure of the initial promise.