### PR TITLE
Fix zipArray Thread Check Failure

### DIFF
--- a/PinkyPromise.xcodeproj/xcshareddata/xcschemes/PinkyPromise_iOS.xcscheme
+++ b/PinkyPromise.xcodeproj/xcshareddata/xcschemes/PinkyPromise_iOS.xcscheme
@@ -26,8 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "058778761E8AB5CB00921CF2"
+            BuildableName = "PinkyPromise.framework"
+            BlueprintName = "PinkyPromise_iOS"
+            ReferencedContainer = "container:PinkyPromise.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +50,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "058778761E8AB5CB00921CF2"
-            BuildableName = "PinkyPromise.framework"
-            BlueprintName = "PinkyPromise_iOS"
-            ReferencedContainer = "container:PinkyPromise.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +70,6 @@
             ReferencedContainer = "container:PinkyPromise.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -433,18 +433,12 @@ public func zipArray<T>(_ promises: [Promise<T>]) -> Promise<[T]> {
         let group = DispatchGroup()
 
         var results: [Result<T, Error>?] = Array(repeating: nil, count: promises.count)
+        let resultsArrayBarrierQueue = DispatchQueue(label: "ThreadSafeResultsArray.queue", attributes: .concurrent)
 
         for (index, promise) in promises.enumerated() {
             promise.inDispatchGroup(group).call { result in
-                //DispatchQueue.main.async {
-                //   results[index] = result
-                //}
-                if Thread.isMainThread {
+                resultsArrayBarrierQueue.sync(flags: .barrier) {
                     results[index] = result
-                } else {
-                  DispatchQueue.main.sync {
-                    results[index] = result
-                  }
                 }
             }
         }

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -436,7 +436,9 @@ public func zipArray<T>(_ promises: [Promise<T>]) -> Promise<[T]> {
 
         for (index, promise) in promises.enumerated() {
             promise.inDispatchGroup(group).call { result in
-                results[index] = result
+                DispatchQueue.main.async {
+                    results[index] = result
+                }
             }
         }
         

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -436,8 +436,15 @@ public func zipArray<T>(_ promises: [Promise<T>]) -> Promise<[T]> {
 
         for (index, promise) in promises.enumerated() {
             promise.inDispatchGroup(group).call { result in
-                DispatchQueue.main.async {
+                //DispatchQueue.main.async {
+                //   results[index] = result
+                //}
+                if Thread.isMainThread {
                     results[index] = result
+                } else {
+                  DispatchQueue.main.sync {
+                    results[index] = result
+                  }
                 }
             }
         }

--- a/Tests/PinkyPromiseTests/PromiseTest.swift
+++ b/Tests/PinkyPromiseTests/PromiseTest.swift
@@ -860,8 +860,6 @@ class PromiseTest: XCTestCase {
         let failure2: Promise<Int> = Promise(error: error2)
         let failure3: Promise<Int> = Promise(error: error3)
 
-       
-
         callAndTestCompletion(zipArray([success1, success2, success3])) {
             TestHelpers.expectSuccess([112, -15, 3], result: $0, message: "Expected to zip 112, -15, and 3 into [112, -15, 3].")
         }

--- a/Tests/PinkyPromiseTests/PromiseTest.swift
+++ b/Tests/PinkyPromiseTests/PromiseTest.swift
@@ -848,7 +848,11 @@ class PromiseTest: XCTestCase {
         let error2 = TestHelpers.uniqueError()
         let error3 = TestHelpers.uniqueError()
 
-        let success1: Promise<Int> = Promise(value: 112)
+        let success1: Promise<Int> = Promise { fulfill in
+            DispatchQueue.global(qos: .userInitiated).async {
+                fulfill(.success(112))
+            }
+        }
         let success2: Promise<Int> = Promise(value: -15)
         let success3: Promise<Int> = Promise(value: 3)
 


### PR DESCRIPTION
The current `zipArray` implementation allows the `results` array to be modified on different threads and thus fails the thread sanitizer check. 

A test was added to expose this by fulfilling a promise off the main thread.

Three solutions, each in a new commit, are contained in this PR:

1. Asynchronous dispatch of result assignment to main

2. Synchronous dispatch of result assignment to main (when not already on main)
I wonder if this is the most correct solution since the `group.notify(queue: DispatchQueue.main)` that processes the results array happens on main? It may be that the barrier solution just happens to run on main in the unit test, thus passes?

3. Use of a GCD Barrier Queue to prevent concurrent assignment to results array